### PR TITLE
Updated lodash to version 3.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "coveralls": "2.11.4"
   },
   "dependencies": {
-    "lodash": "2.4.2",
+    "lodash": "3.10.1",
     "pathval": "0.1.1",
     "when": "3.7.3",
     "js-yaml": "3.4.2",


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>